### PR TITLE
Add DISCO_L475VG_IOT + DISCO_F413ZH + DISCO_F469NI + DISCO_F746NG + DISCO_L476VG

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -200,14 +200,14 @@ bool TestWriteReadSimple()
         printf("\nERROR: Device not ready, tests failed\n");
         return false;
     }
-    
+
     printf(">>>>>>>>>>>>>>>>>>>>START WRITING...\n");
     /* bit mask last 8 bits of the adress */
     result = myQspi->write(QSPI_PAGE_PROG_CMD, -1, 0, (flash_addr & 0x00FFFF00), tx_buf, &buf_len );
     if( ( result != QSPI_STATUS_OK ) || buf_len != sizeof(tx_buf) ) {
         printf("\nERROR: Write failed. result = %d, bu_len= %lu", result, (uint32_t)buf_len);
     }
-        
+
     if( false == WaitForMemReady()) {
         printf("\nERROR: Device not ready, tests failed\n");
         return false;
@@ -215,10 +215,10 @@ bool TestWriteReadSimple()
     
     memset( rx_buf, 0, sizeof(rx_buf) );
     printf(">>>>>>>>>>>>>>>>>>>>START READING...\n");
-    /* TEST IS KO WITH THIS READ FUNCTION :     */
-    //result = myQspi->read(QSPI_FAST_READ_CMD, 0, 8, flash_addr, rx_buf, &buf_len );
     /* TEST IS OK WITH THIS READ FUNCTION :     */
-    result = myQspi->read(QSPI_SIMPLE_READ_CMD, -1, 0, flash_addr, rx_buf, &buf_len );
+    result = myQspi->read(QSPI_FAST_READ_CMD, -1, 8, flash_addr, rx_buf, &buf_len );
+    /* TEST IS also OK WITH THIS READ FUNCTION :     */
+    //result = myQspi->read(QSPI_SIMPLE_READ_CMD, -1, 0, flash_addr, rx_buf, &buf_len );
     if( result != QSPI_STATUS_OK ) {
         printf("\nERROR: Read failed");
         return false;

--- a/main.cpp
+++ b/main.cpp
@@ -386,7 +386,7 @@ bool WaitForMemReady()
                                   0,              // do not transmit
                                   status_value,                 // just receive two bytes of data
                                   2)) {   // store received values in status_value
-            VERBOSE_PRINT(("\nReadng Status Register Success: value = 0x%02X:0x%02X\n", status_value[0], status_value[1]));
+//            VERBOSE_PRINT(("\nReadng Status Register Success: value = 0x%02X%02X\n", status_value[0], status_value[1]));
         } else {
             printf("\nERROR: Reading Status Register failed\n");
         }
@@ -396,14 +396,11 @@ bool WaitForMemReady()
         printf("WaitforMemReady FALSE\n");
         return false;
     }
-    printf("WaitforMemReady TRUE\n");
     return true;
 }
 
 bool SectorErase(unsigned int flash_addr)
 {
-    printf("Sector Erase start \n");
-
     //Send WREN
     if (!WriteEnable()) {
         return false;
@@ -420,7 +417,7 @@ bool SectorErase(unsigned int flash_addr)
                               0,              // do not transmit
                               NULL,                 // just receive two bytes of data
                               0)) {   // store received values in status_value
-        VERBOSE_PRINT(("\nSending SECT_ERASE command success\n"));
+//        VERBOSE_PRINT(("\nSending SECT_ERASE command success\n"));
     } else {
         VERBOSE_PRINT(("\nERROR: Sending SECT_ERASE command failed\n"));
         return false;
@@ -430,7 +427,6 @@ bool SectorErase(unsigned int flash_addr)
         VERBOSE_PRINT(("\nERROR: Device not ready, tests failed\n"));
         return false;
     }
-    VERBOSE_PRINT(("Sector Erase OK\n"));
 
     return true;
 }
@@ -447,7 +443,6 @@ bool WriteEnable()
         VERBOSE_PRINT(("\nERROR:Sending WREN command FAILED\n"));
         return false;
     }
-    printf("\n end of write enable OK\n");
     return true;
 }
 
@@ -546,8 +541,6 @@ bool mx25r6435f_write(unsigned int flash_addr, const char *tx_buffer, size_t tx_
         if (result != QSPI_STATUS_OK) {
             printf("\nERROR: Write failed. Result=%d, Current_size=%d\n", result, current_size);
             return false;
-        } else {
-            printf("\n Write OK\n");
         }
 
         if (!WaitForMemReady()) {
@@ -610,7 +603,6 @@ bool TestWriteReadBlockMultiplePattern()
         if( ( result != true ) || buf_len != _1_K_ ) {
             printf("\nERROR: Write failed");
             return false;
-        } else { printf("\n Write OK\n");
         }
 
         if( false == WaitForMemReady()) {
@@ -628,13 +620,10 @@ bool TestWriteReadBlockMultiplePattern()
         if( result != QSPI_STATUS_OK ) {
             printf("\nERROR: Read failed");
             return false;
-        } else { printf("\n read OK\n");
         }
         if( buf_len != _1_K_ ) {
             printf( "\nERROR: Unable to read the entire buffer" );
             return false;
-        } else {
-            printf("Size read ok\n");
         }
 
         for (size_t i = 0; i<_1_K_; i++) {
@@ -643,8 +632,6 @@ bool TestWriteReadBlockMultiplePattern()
                 return false;
             }
         }
-        printf("test_rx_buf content OK \n");
-
         flash_addr += 0x1000;
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -8,7 +8,8 @@
 #define MX25R6435F
 
 #elif (defined(TARGET_DISCO_F413ZH) || \
-       defined(TARGET_DISCO_F469NI))
+       defined(TARGET_DISCO_F469NI) || \
+       defined(TARGET_DISCO_F746NG))
 #define N25Q128A13EF840
 
 #else
@@ -166,7 +167,6 @@
 #define QSPI_PIN_CSN PE_11
 
 #elif defined(TARGET_DISCO_F413ZH)
-
 #define QSPI_PIN_IO0 PF_8
 #define QSPI_PIN_IO1 PF_9
 #define QSPI_PIN_IO2 PE_2
@@ -174,6 +174,13 @@
 #define QSPI_PIN_SCK PB_2
 #define QSPI_PIN_CSN PG_6
 
+#elif defined(TARGET_DISCO_F746NG)
+#define QSPI_PIN_IO0 PD_11
+#define QSPI_PIN_IO1 PD_12
+#define QSPI_PIN_IO2 PE_2
+#define QSPI_PIN_IO3 PD_13
+#define QSPI_PIN_SCK PB_2
+#define QSPI_PIN_CSN PB_6
 
 #endif
 

--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,8 @@
 
 #elif (defined(TARGET_DISCO_F413ZH) || \
        defined(TARGET_DISCO_F469NI) || \
-       defined(TARGET_DISCO_F746NG))
+       defined(TARGET_DISCO_F746NG) || \
+       defined(TARGET_DISCO_L476VG))
 #define N25Q128A13EF840
 
 #else
@@ -181,6 +182,14 @@
 #define QSPI_PIN_IO3 PD_13
 #define QSPI_PIN_SCK PB_2
 #define QSPI_PIN_CSN PB_6
+
+#elif defined(TARGET_DISCO_L476VG)
+#define QSPI_PIN_IO0 PE_12
+#define QSPI_PIN_IO1 PE_13
+#define QSPI_PIN_IO2 PE_14
+#define QSPI_PIN_IO3 PE_15
+#define QSPI_PIN_SCK PE_10
+#define QSPI_PIN_CSN PE_11
 
 #endif
 

--- a/main.cpp
+++ b/main.cpp
@@ -149,7 +149,7 @@ int main() {
     // Run tests in QUADSPI 1_1_1 mode
     ///////////////////////////////////////////
     printf("\n\nQSPI Config = 1_1_1");
-    if(QSPI_STATUS_OK == myQspi->configure_format( QSPI_CFG_BUS_SINGLE, QSPI_CFG_BUS_SINGLE, QSPI_CFG_ADDR_SIZE_24, QSPI_CFG_BUS_SINGLE, QSPI_CFG_ALT_SIZE_8, QSPI_CFG_BUS_SINGLE, 0, 0 )) {
+    if(QSPI_STATUS_OK == myQspi->configure_format( QSPI_CFG_BUS_SINGLE, QSPI_CFG_BUS_SINGLE, QSPI_CFG_ADDR_SIZE_24, QSPI_CFG_BUS_SINGLE, QSPI_CFG_ALT_SIZE_8, QSPI_CFG_BUS_SINGLE, 0)) {
         printf("\nConfigured QSPI driver configured succesfully");
     } else {
         printf("\nERROR: Failed configuring QSPI driver");

--- a/main.cpp
+++ b/main.cpp
@@ -13,8 +13,6 @@
        defined(TARGET_DISCO_L476VG))
 #define N25Q128A13EF840
 
-#else
-#error "Please define a flash type"
 #endif
 
 /* MEMORY DEFINES */
@@ -99,34 +97,6 @@
 
 #define QSPI_DUALREAD_DUMMYCYCLES           (4)
 #define QSPI_QUADREAD_DUMMYCYCLES           (4)
-#elif defined(N25Q128A)
-
-// almost identical than MX25R6435F, just that sector erase is above for subsector erase?
-
-// Command for reading status register
-#define QSPI_STD_CMD_RDSR                   0x05
-// Command for writing status register
-#define QSPI_STD_CMD_WRSR                   0x01
-// Command for reading control register (supported only by some memories)
-#define QSPI_STD_CMD_RDCR                   0x35
-// Command for writing control register (supported only by some memories)
-#define QSPI_STD_CMD_WRCR                   0x3E
-// Command for setting Reset Enable (supported only by some memories)
-#define QSPI_STD_CMD_RSTEN                  0x66
-// Command for setting Reset (supported only by some memories)
-#define QSPI_STD_CMD_RST                    0x99
-// Command for setting WREN (supported only by some memories)
-#define QSPI_STD_CMD_WREN                   0x06
-// Command for Sector erase (supported only by some memories)
-#define QSPI_STD_CMD_SECT_ERASE             0x20
- // use generic values
-
-#define QSPI_PP_COMMAND_NRF_ENUM            (0x02)
-#define QSPI_READ2O_COMMAND_NRF_ENUM        (0x3B)
-#define QSPI_READ2IO_COMMAND_NRF_ENUM       (0xBB)
-#define QSPI_PP4IO_COMMAND_NRF_ENUM         (0x38) // TODO: cant find this in the datasheet
-#define QSPI_READQUAD_COMMAND_NRF_ENUM      (0x6B)
-#define QSPI_READ4IO_COMMAND_NRF_ENUM       (0xEB)
 
 #elif defined (TARGET_NORDIC)
 // Read/Write commands

--- a/main.cpp
+++ b/main.cpp
@@ -182,9 +182,7 @@ int main() {
 
 bool TestWriteReadSimple()
 {
-    printf("TestWriteReadSimple start\n");
-    // TODO from the table for this flash, seems like 9 for fast read is supported
-    //myQspi->set_frequency(9000000);
+    printf("\n********************************************************\nTestWriteReadSimple start\n********************************************************\n");
     int result = 0;
     char tx_buf[] = { 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78, 0x89, 0x10, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x2F };    
     char rx_buf[16];    

--- a/main.cpp
+++ b/main.cpp
@@ -109,9 +109,10 @@
     {                                                   \
         printf("\nExecuting test: %-40s :", #test );    \
         if( false == test() ) {                         \
-            printf(" FAILED" );                         \
+            printf(" FAILED\n" );                         \
+            return -1;                                  \
         } else {                                        \
-            printf(" PASSED" );                         \
+            printf(" %s PASSED\n", #test );               \
         }                                               \
     }                                                   \
 

--- a/main.cpp
+++ b/main.cpp
@@ -4,10 +4,19 @@
 #include "QSPI.h"
 
 // define what flash we got
-//#define MX25R6435F       // DISCO_L475VG_IOT01A
-#define N25Q128A13EF840F   // DISCO_F413ZH
+#if defined(TARGET_DISCO_L475VG_IOT01A)
+#define MX25R6435F
 
-#if defined(N25Q128A13EF840F)
+#elif (defined(TARGET_DISCO_F413ZH) || \
+       defined(TARGET_DISCO_F469NI))
+#define N25Q128A13EF840
+
+#else
+#error "Please define a flash type"
+#endif
+
+/* MEMORY DEFINES */
+#if defined(N25Q128A13EF840)
 
 #define QSPI_PP_COMMAND_NRF_ENUM            (0x02)
 #define QSPI_READ2O_COMMAND_NRF_ENUM        (0x3B)
@@ -48,6 +57,7 @@
 
 #define QSPI_DUALREAD_DUMMYCYCLES           (8)
 #define QSPI_QUADREAD_DUMMYCYCLES           (10)
+
 #elif defined(MX25R6435F)
 // Command for reading status register
 #define QSPI_STD_CMD_RDSR                   0x05
@@ -136,6 +146,7 @@
 
 #endif
 
+/* PINOUT DEFINES */
 
 #if defined(TARGET_DISCO_F469NI)
 #define QSPI_PIN_IO0 PF_8
@@ -162,6 +173,7 @@
 #define QSPI_PIN_IO3 PD_13
 #define QSPI_PIN_SCK PB_2
 #define QSPI_PIN_CSN PG_6
+
 
 #endif
 
@@ -194,7 +206,7 @@ bool WriteEnable();
 #if defined(MX25R6435F)
 bool mx25r6435f_HighPerfQuadMode();
 #endif
-#if defined(N25Q128A13EF840F)
+#if defined(N25Q128A13EF840)
 bool ProgramDummyCycles(uint8_t dummycnt);
 #endif
 bool mx25r6435f_write(unsigned int flash_addr, const char *tx_buffer, size_t tx_length);
@@ -395,7 +407,7 @@ bool InitializeFlashMem()
     }
 #endif
 
-#if defined(N25Q128A13EF840F)
+#if defined(N25Q128A13EF840)
     if (!ProgramDummyCycles(8)) {
         VERBOSE_PRINT(("Error programming dummy clces\n"));
         return false;
@@ -1032,7 +1044,7 @@ bool TestWriteReadCustomCommands()
     }
 
     memset( rx_buf, 0, sizeof(rx_buf) );
-#if defined(N25Q128A13EF840F)
+#if defined(N25Q128A13EF840)
     if (!ProgramDummyCycles(8)) {
         printf("\nError dummy cycles programmation\n");
         return false;
@@ -1136,7 +1148,7 @@ bool TestWriteReadCustomCommands()
     }
 
     memset( rx_buf, 0, sizeof(rx_buf) );
-#if defined(N25Q128A13EF840F)
+#if defined(N25Q128A13EF840)
     if (!ProgramDummyCycles(QSPI_QUADREAD_DUMMYCYCLES)) {
         printf("\nError dummy cycles programmation\n");
         return false;
@@ -1171,7 +1183,7 @@ bool TestWriteReadCustomCommands()
     return true;
 }
 
-#if defined(N25Q128A13EF840F)
+#if defined(N25Q128A13EF840)
 bool ProgramDummyCycles(uint8_t dummycnt)
 {
     char status_value[2];

--- a/main.cpp
+++ b/main.cpp
@@ -165,6 +165,7 @@ int main() {
     
     DO_TEST( TestWriteReadSimple );
     DO_TEST(TestWriteReadBlockMultiplePattern);
+    DO_TEST(TestWriteMultipleReadSingle);
     if(NULL != myQspi)    
         delete myQspi;
     if(NULL != myQspiOther)
@@ -633,6 +634,92 @@ bool TestWriteReadBlockMultiplePattern()
         printf("test_rx_buf content OK \n");
 
         flash_addr += 0x1000;
+    }
+
+    free(test_rx_buf);
+    free(test_tx_buf);
+
+    return true;
+}
+
+bool TestWriteMultipleReadSingle()
+{
+    char *test_tx_buf = NULL;
+    char *test_rx_buf = NULL;
+    char *test_tx_buf_aligned = NULL;
+    char *test_rx_buf_aligned = NULL;
+    char *tmp = NULL;
+    uint32_t flash_addr = 0;
+    int result = 0;
+    size_t buf_len = 0;
+    char pattern_buf[] = { 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78, 0x89, 0x10, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x2F };  
+    unsigned int start_addr = 0x2000;
+    printf("\n********************************************************\nTestWriteMultipleReadSingle start\n********************************************************\n");
+
+    test_tx_buf = NULL;
+    test_tx_buf = (char *)malloc( _1_K_ * 5 ); //Alloc 5k to get a 1K boundary
+    if(test_tx_buf == NULL) {
+        printf("\nERROR: tx buf alloc failed");
+        return false;
+    }
+    test_tx_buf_aligned = (char *)((((uint32_t)test_tx_buf) + _1_K_) & 0xFFFFFC00);
+
+    test_rx_buf = NULL;
+    test_rx_buf = (char *)malloc( _1_K_ * 5 ); //Alloc 5k to get a 1K boundary
+    if(test_rx_buf == NULL) {
+        printf("\nERROR: rx buf alloc failed");
+        return false;
+    }
+    test_rx_buf_aligned = (char *)((((uint32_t)test_rx_buf) + _1_K_) & 0xFFFFFC00);
+
+    flash_addr = start_addr;
+    /* It's ok to erase only 1 sector as start_addr=0x2000 is aligned with a 4K sector start */
+    if( false == SectorErase(flash_addr)) {
+        printf("\nERROR: SectorErase failed(addr = 0x%08X)\n", flash_addr);
+        return false;
+    }
+
+    if( false == WaitForMemReady()) {
+        printf("\nDevice not ready, tests failed\n");
+        return false;
+    }
+
+    /* Handle several 1 K write */
+    tmp = test_tx_buf_aligned;
+    for( int i=0; i < 4; i++) {
+        printf(">>>>>>>>>>FOR LOOP ... %d of 4\n", i);
+        memset( tmp, pattern_buf[i], _1_K_ );
+        buf_len = _1_K_; //1k
+        result = mx25r6435f_write( flash_addr, tmp, buf_len );
+        if( ( result != true ) || buf_len != _1_K_ ) {
+            printf("\nERROR: Write failed");
+            return false;
+        }
+
+        if( false == WaitForMemReady()) {
+            printf("\nERROR: Device not ready, tests failed\n");
+            return false;
+        }
+        flash_addr += _1_K_;
+        tmp += _1_K_;
+    }
+
+    /* Handle 4K read in a single call */
+    memset( test_rx_buf_aligned, 0, _4_K_ );
+    buf_len = _4_K_; //4 * 1k
+    flash_addr = start_addr;
+    result = myQspi->read(QSPI_FAST_READ_CMD, -1, 8, flash_addr, test_rx_buf_aligned, &buf_len );
+    if( result != QSPI_STATUS_OK ) {
+        printf("\nERROR: Read failed");
+        return false;
+    }
+    if( buf_len != _4_K_ ) {
+        printf( "\nERROR: Unable to read the entire buffer" );
+        return false;
+    }
+    if(0 != (memcmp( test_rx_buf_aligned, test_tx_buf_aligned, _4_K_))) {
+        printf("\nERROR: Buffer contents are invalid");
+        return false;
     }
 
     free(test_rx_buf);


### PR DESCRIPTION
With this PR, both MX25R64 and N25Q128A flash memories are supported.
This means the following target list:
DISCO_L475VG_IOT01A
DISCO_F413ZH
DISCO_F469NI
DISCO_F746NG
DISCO_L476VG

Some PRs will be done for the platforms' support on mbed-os repo, feature-qspi branch

